### PR TITLE
Improve consistency of web3 provider injection.

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewClient.java
@@ -76,8 +76,8 @@ public class RNCWebViewClient extends WebViewClient {
     }
 
     @Override
-    public void onPageStarted(WebView webView, String url, Bitmap favicon) {
-      super.onPageStarted(webView, url, favicon);
+    public void onPageCommitVisible(WebView webView, String url) {
+      super.onPageCommitVisible(webView, url);
       mLastLoadFailed = false;
 
       RNCWebView reactWebView = (RNCWebView) webView;


### PR DESCRIPTION
onPageCommitVisible is execute whe the body of the HTTP response has started loading and it is reflected in the DOM.

As with onPageStarted as soon as the page started loading, causing issues on cold starts where the DOM wouldn't be ready.

More info here: https://developer.android.com/reference/android/webkit/WebViewClient#onPageCommitVisible(android.webkit.WebView,%20java.lang.String)

Must be on Andorid API level 23 upwards