### PR TITLE
Release 14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "13.6.3",
+  "version": "14.0.0",
   "homepage": "https://github.com/MetaMask/react-native-webview-mm#readme",
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
This is the release candidate for `14.0.0`.

This will be the first release as a forked `@metamask/react-native-webview`

---

#### Blocked by
- [x] #15 