### PR TITLE
disable windows-ci and update gradle build on android-ci

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn --frozen-lockfile
         shell: bash
       - name: Build Android test app
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43
         with:
           gradle-version: wrapper
           arguments: -PnewArchEnabled=${{matrix.newArchEnabled}} --no-daemon clean build check test

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: yarn --frozen-lockfile
         shell: bash
       - name: Build Android test app
-        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43
+        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 #v3.3.2
         with:
           gradle-version: wrapper
           arguments: -PnewArchEnabled=${{matrix.newArchEnabled}} --no-daemon clean build check test

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,5 +1,5 @@
 name: Windows CI
-on: [pull_request]
+on:
 
 jobs:
   run-windows-tests:


### PR DESCRIPTION
This PR:
- upgrades the gradle GH action in `android-ci` 
   - GH grade action was upgraded due because the action was depreciated 
   - Action also needed to be allow listed in repo actions 
- Disables who `windows-ci` action that is not needed
   - This was disabled as we don't use widows machine for development and the overhead/maintenance was not needed 