### PR TITLE
fix: actually publish podspec file after rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "src",
     "index.js",
     "index.d.ts",
-    "react-native-webview.podspec",
+    "react-native-webview-mm.podspec",
     "react-native.config.js"
   ],
   "resolutions": {


### PR DESCRIPTION
Follow-up to #15, which renamed the file without updating the `files` entry in package manifest.