### PR TITLE
feat: For Downloading dialog on Android add 500ms delay for the Positive button to become enabled to prevent accidental downloads

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -1,8 +1,6 @@
 package com.reactnativecommunity.webview
 
-import android.app.AlertDialog
 import android.app.DownloadManager
-import android.content.DialogInterface
 import android.content.pm.ActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Color
@@ -27,6 +25,7 @@ import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.uimanager.ThemedReactContext
 import com.reactnativecommunity.webview.extension.file.Base64FileDownloader
 import com.reactnativecommunity.webview.extension.file.BlobFileDownloader
+import com.reactnativecommunity.webview.extension.file.TapjackingPreventionAlertDialog
 import com.reactnativecommunity.webview.extension.file.addBlobFileDownloaderJavascriptInterface
 import org.json.JSONException
 import org.json.JSONObject
@@ -146,10 +145,12 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
             if (Bidi(fileName, Bidi.DIRECTION_DEFAULT_LEFT_TO_RIGHT).isMixed) {
                 Toast.makeText(webView.context, "Invalid filename or type", Toast.LENGTH_LONG).show()
             } else {
-                val builder = AlertDialog.Builder(webView.context)
-                builder.setMessage("Do you want to download \n$fileName?")
-                builder.setCancelable(false)
-                builder.setPositiveButton("Download") { _, _ ->
+                TapjackingPreventionAlertDialog(
+                  context = webView.context,
+                  message = "Do you want to download \n$fileName?",
+                  positiveButtonText = "Download",
+                  negativeButtonText = "Cancel",
+                  onPositiveButtonClick = {
                     //Attempt to add cookie, if it exists
                     var urlObj: URL? = null
                     try {
@@ -178,10 +179,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
                                 getDownloadingMessageOrDefault()
                         )
                     }
-                }
-                builder.setNegativeButton("Cancel") { _: DialogInterface?, _: Int -> }
-                val alertDialog = builder.create()
-                alertDialog.show()
+                }).show()
             }
         })
         return RNCWebViewWrapper(context, webView)

--- a/android/src/main/java/com/reactnativecommunity/webview/extension/file/Base64FileDownloader.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/extension/file/Base64FileDownloader.kt
@@ -1,10 +1,8 @@
 package com.reactnativecommunity.webview.extension.file
 
 import android.Manifest
-import android.app.AlertDialog
 import android.content.ContentValues
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -59,23 +57,13 @@ internal object Base64FileDownloader {
 	}
 
 	private fun showAlertDialog(context: Context, extension: String, onPositiveButtonClick: () -> Unit) {
-		AlertDialog.Builder(context)
-			.apply {
-				setMessage("Do you want to download \nFile.${extension}?")
-				setCancelable(false)
-				setPositiveButton("Download", object : DialogInterface.OnClickListener {
-					override fun onClick(p0: DialogInterface?, p1: Int) {
-						onPositiveButtonClick()
-					}
-				})
-				setNegativeButton("Cancel", object : DialogInterface.OnClickListener {
-					override fun onClick(p0: DialogInterface?, p1: Int) {
-						// Do nothing
-					}
-				})
-			}
-			.create()
-			.show()
+    TapjackingPreventionAlertDialog(
+      context = context,
+      message = "Do you want to download \nFile.${extension}?",
+      positiveButtonText = "Download",
+      negativeButtonText = "Cancel",
+      onPositiveButtonClick = onPositiveButtonClick,
+    ).show()
 	}
 
 

--- a/android/src/main/java/com/reactnativecommunity/webview/extension/file/TapjackingPreventionAlertDialog.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/extension/file/TapjackingPreventionAlertDialog.kt
@@ -1,0 +1,51 @@
+package com.reactnativecommunity.webview.extension.file
+
+import android.content.Context
+import android.support.v7.app.AlertDialog
+
+/**
+ * For the first 500ms disabled Positive button to prevent accidental taps
+ */
+class TapjackingPreventionAlertDialog(
+  context: Context,
+  private val message: String,
+  private val positiveButtonText: String,
+  private val negativeButtonText: String,
+  private val onPositiveButtonClick: () -> Unit,
+) {
+  private val dialog: AlertDialog = AlertDialog.Builder(context)
+    .setCancelable(false)
+    .setMessage(message)
+    .setPositiveButton(positiveButtonText, null)
+    .setNegativeButton(negativeButtonText, null)
+    .create()
+
+  fun show() {
+    dialog.setOnShowListener {
+      val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+      val negativeButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+
+      // Disable Positive button to prevent accidental tap
+      positiveButton.isEnabled = false
+
+      positiveButton.postDelayed({
+        positiveButton.isEnabled = true
+      }, PREVENT_ACCIDENTAL_TAP_WAITING_TIME_MS)
+
+      positiveButton.setOnClickListener {
+        onPositiveButtonClick.invoke()
+        dialog.dismiss()
+      }
+
+      negativeButton.setOnClickListener {
+        dialog.dismiss()
+      }
+    }
+
+    dialog.show()
+  }
+
+  companion object {
+    const val PREVENT_ACCIDENTAL_TAP_WAITING_TIME_MS = 500L
+  }
+}


### PR DESCRIPTION
Issue 2190 https://github.com/MetaMask/mobile-planning/issues/2190

### On the video there is a 5 Sec delay for better visibility of the fix. Actual value is 0.5 sec
https://github.com/user-attachments/assets/be41932b-b8ce-41d9-8e7c-7638b1530660

