### PR TITLE
fix: Inject Javascript to Remove Service Worker on iOS from WkWebView

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1853,6 +1853,45 @@ didFinishNavigation:(WKNavigation *)navigation
   WKUserScript *userScript = [[WKUserScript alloc] initWithSource:html5HistoryAPIShimSource injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES];
   [wkWebViewConfig.userContentController addUserScript:userScript];
 
+  NSString *serviceWorkerPreventCrashesSource = @"(function() {\n"
+    "    if (!('serviceWorker' in navigator)) {\n"
+    "        Object.defineProperty(navigator, 'serviceWorker', {\n"
+    "            value: {\n"
+    "                register: function(scriptURL, options) {\n"
+    "                    return Promise.resolve({\n"
+    "                        installing: null,\n"
+    "                        waiting: null,\n"
+    "                        active: {\n"
+    "                            scriptURL: scriptURL,\n"
+    "                            state: 'activated'\n"
+    "                        },\n"
+    "                        scope: options?.scope || '/',\n"
+    "                        update: () => Promise.resolve(),\n"
+    "                        unregister: () => Promise.resolve(true)\n"
+    "                    });\n"
+    "                },\n"
+    "                getRegistration: () => Promise.resolve(null),\n"
+    "                getRegistrations: () => Promise.resolve([]),\n"
+    "                ready: Promise.resolve({\n"
+    "                    installing: null,\n"
+    "                    waiting: null,\n"
+    "                    active: null,\n"
+    "                    scope: '/'\n"
+    "                }),\n"
+    "                controller: null,\n"
+    "                addEventListener() {},\n"
+    "                removeEventListener() {}\n"
+    "            },\n"
+    "            configurable: true\n"
+    "        });\n"
+    "    }\n"
+    "})();";
+  WKUserScript *serviceWorkerPreventCrashesScript = [[WKUserScript alloc]
+    initWithSource:serviceWorkerPreventCrashesSource
+    injectionTime:WKUserScriptInjectionTimeAtDocumentStart
+    forMainFrameOnly:NO];
+  [wkWebViewConfig.userContentController addUserScript:serviceWorkerPreventCrashesScript];
+
   if(_sharedCookiesEnabled) {
     // More info to sending cookies with WKWebView
     // https://stackoverflow.com/questions/26573137/can-i-set-the-cookies-to-be-used-by-a-wkwebview/26577303#26577303


### PR DESCRIPTION
We have a problem with opening some websites which rely on Service Workers and don't handle their unavailable state. For example, https://www.niftyisland.com is crashing on iOS:
<details>
<summary>Screenshot</summary>
![image (1)](https://github.com/user-attachments/assets/6d5894ed-7f11-48b6-a429-8c8699794c3b)
</details>

Service Workers are not supported on iOS in WkWebView:
https://developer.apple.com/forums/thread/773539
https://stackoverflow.com/questions/63674612/wkwebview-service-workers

To prevent such crashes we can inject Javascript code to mock Service Workers if they're not supported. This mock won't do anything except preventing the problem.
<details>
<summary>Screenshot of working website</summary>
![Simulator Screenshot - iPhone 16 Plus - 2025-06-11 at 16 16 12](https://github.com/user-attachments/assets/68ebc688-3ad6-44a6-9845-f51ac5cf4ae7)
</details>