### PR TITLE
fix: Download file requested when connecting to any Dapp

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -123,7 +123,7 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
 			      	  return@DownloadListener
 			      }
 			      if (url.startsWith("blob:")) {
-                      // Handled in RNCWebView.injectBlobFileDownloaderScript()
+                webView.evaluateJavascriptWithFallback(BlobFileDownloader.getDownloadBlobInterceptor(url))
 			      	  return@DownloadListener
 			      }
             webView.setIgnoreErrFailedForThisURL(url)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "14.2.0",
+  "version": "14.2.1",
   "homepage": "https://github.com/MetaMask/react-native-webview-mm#readme",
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Thibault Malbranche <malbranche.thibault@gmail.com>"
   ],
   "license": "MIT",
-  "version": "14.2.1",
+  "version": "14.2.0",
   "homepage": "https://github.com/MetaMask/react-native-webview-mm#readme",
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Issue in the tracker: https://github.com/MetaMask/metamask-mobile/issues/16528

Previous JS injection was catching a Blob file creation and triggered downloading immediately. Turned out some Dapps may create Blob files without user actually trying to download these files. To prevent the issue, we try to download Blobs only on clicks on download elements in the website or when Android receives a download callback.

To test Blob file downloading I use two websites:
https://eligrey.com/demos/FileSaver.js/
https://tyschenko.github.io/download_blob_file.html

Screenshot of the problem in **Uniswap.org** Dapp:
<img width="449" alt="457889042-5c20882c-aec2-44a1-8f98-04c9a1d73bbd" src="https://github.com/user-attachments/assets/42d22696-2a18-41cf-ac5c-51c6dfa45f94" />

Video of the solution showing downloading of Blob files and opening of **Uniswap.org** and **pancakeswap.finance** Dapps:
https://github.com/user-attachments/assets/991b9a3b-a9f6-4c72-b25f-1133832ef1f0