### PR TITLE
fix: On iOS on opening of some Dapps there is download file pop up

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1390,7 +1390,8 @@ RCTAutoInsetsProtocol>
     static dispatch_once_t onceToken;
 
     NSString *urlString = navigationAction.request.URL.absoluteString;
-    if ([urlString hasPrefix:@"blob:"]) {
+    // Some Dapps on opening send to mobile blob: urls. We ignore them and handle only urls which were received on clicks on Link (based on navigationType)
+    if ([urlString hasPrefix:@"blob:"] && navigationAction.navigationType == WKNavigationTypeLinkActivated) {
         if (_onFileDownload) {
             [self handleBlobDownloadUrl:urlString];
             decisionHandler(WKNavigationActionPolicyCancel);


### PR DESCRIPTION
Issue: https://github.com/MetaMask/metamask-mobile/issues/16690

Visiting Raydium.io/swap in the in-app browser triggers a dialog that says "Do you want to download File.bin?"
This does not happen when visiting the same site on Phantom's in-app browser.

This happens because this Dapp on opening initiates blob: file downloading. To prevent it we check if the blob url is coming from click.

https://github.com/user-attachments/assets/9dec2b87-b353-4c06-bc3e-aca7176080f2