### PR TITLE
fix: In publish-release job update subteam to point to metamask-npm-publishers instead of mobile platform in Slack

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -45,7 +45,7 @@ jobs:
         uses: MetaMask/action-npm-publish@v5
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          subteam: S04EF225J1M # @metamask-mobile-platform
+          subteam: S042S7RE4AE # @metamask-npm-publishers
         env:
           SKIP_PREPACK: true
 


### PR DESCRIPTION
Was requested here https://consensys.slack.com/archives/C1L7H42BT/p1753115931359209