### PR TITLE
fix: Prevent image downloading and recognize SVG MIME types

### DIFF
--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1016,6 +1016,7 @@ RCTAutoInsetsProtocol>
             @"image/png": @"png",
             @"image/jpeg": @"jpg",
             @"image/gif": @"gif",
+            @"image/svg+xml": @"svg",
             @"application/pdf": @"pdf",
             @"text/plain": @"txt",
             @"application/json": @"json",
@@ -2126,7 +2127,6 @@ didFinishNavigation:(WKNavigation *)navigation
     
     NSString *extension = [url.pathExtension lowercaseString];
     NSSet *downloadableExtensions = [NSSet setWithObjects:
-        @"jpg", @"jpeg", @"png", @"gif", @"bmp", @"webp", @"svg",  // Images
         @"pdf", @"doc", @"docx", @"xls", @"xlsx", @"ppt", @"pptx", // Documents
         @"txt", @"rtf", @"csv", @"json", @"xml",                   // Text files
         @"zip", @"rar", @"7z", @"tar", @"gz",                      // Archives


### PR DESCRIPTION
This PR is to fix an issue whereby users were seemingly being prompt to download `.bin` files. This was occurring because `bin` files are the default extension assigned to blobs whose MIME types are not recognized. The solution is two-fold:
a.) Make the WebView recognize SVG MIME type
b.) Omit image MIME types from being downloaded, in lieu of just displaying them

https://github.com/MetaMask/metamask-mobile/issues/18475