### PR TITLE
feat: add allowFileDownloads and suppressJavaScriptDialogs props

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebChromeClient.java
@@ -15,6 +15,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.ConsoleMessage;
 import android.webkit.GeolocationPermissions;
+import android.webkit.JsResult;
 import android.webkit.JsPromptResult;
 import android.webkit.PermissionRequest;
 import android.webkit.ValueCallback;
@@ -62,6 +63,7 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
     // This boolean block JS prompts and alerts from displaying during loading
     protected boolean blockJsDuringLoading = true;
+    protected boolean suppressJavaScriptDialogs = false;
 
     /*
      * - Permissions -
@@ -445,12 +447,30 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
     @Override
     public boolean onJsPrompt(WebView view, String url, String message, String defaultValue, JsPromptResult result) {
-        if (blockJsDuringLoading) {
+        if (shouldSuppressDialogs()) {
             result.cancel();
             return true;
         } else {
             return super.onJsPrompt(view, url, message, defaultValue, result);
         }
+    }
+
+    @Override
+    public boolean onJsAlert(WebView view, String url, String message, JsResult result) {
+        if (shouldSuppressDialogs()) {
+            result.cancel();
+            return true;
+        }
+        return super.onJsAlert(view, url, message, result);
+    }
+
+    @Override
+    public boolean onJsConfirm(WebView view, String url, String message, JsResult result) {
+        if (shouldSuppressDialogs()) {
+            result.cancel();
+            return true;
+        }
+        return super.onJsConfirm(view, url, message, result);
     }
 
     @Override
@@ -485,5 +505,13 @@ public class RNCWebChromeClient extends WebChromeClient implements LifecycleEven
 
     public void setHasOnOpenWindowEvent(boolean hasEvent) {
       mHasOnOpenWindowEvent = hasEvent;
+    }
+
+    public void setSuppressJavaScriptDialogs(boolean suppress) {
+      suppressJavaScriptDialogs = suppress;
+    }
+
+    private boolean shouldSuppressDialogs() {
+      return suppressJavaScriptDialogs || blockJsDuringLoading;
     }
 }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -81,6 +81,8 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
     protected boolean hasScrollEvent = false;
     protected boolean nestedScrollEnabled = false;
     protected ProgressChangedFilter progressChangedFilter;
+    protected boolean allowFileDownloads = true;
+    protected boolean suppressJavaScriptDialogs = false;
 
     /** Samsung Manufacturer Name */
     private static final String SAMSUNG_MANUFACTURER_NAME = "samsung";
@@ -119,6 +121,22 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
 
     public void setNestedScrollEnabled(boolean nestedScrollEnabled) {
         this.nestedScrollEnabled = nestedScrollEnabled;
+    }
+
+    public void setAllowFileDownloads(boolean allow) {
+        this.allowFileDownloads = allow;
+    }
+
+    public boolean getAllowFileDownloads() {
+        return this.allowFileDownloads;
+    }
+
+    public void setSuppressJavaScriptDialogs(boolean suppress) {
+        this.suppressJavaScriptDialogs = suppress;
+    }
+
+    public boolean getSuppressJavaScriptDialogs() {
+        return this.suppressJavaScriptDialogs;
     }
 
     @Override

--- a/android/src/main/java/com/reactnativecommunity/webview/extension/file/BlobFileDownloader.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/extension/file/BlobFileDownloader.kt
@@ -1,6 +1,5 @@
 package com.reactnativecommunity.webview.extension.file
 
-import android.content.Context
 import android.webkit.JavascriptInterface
 import com.reactnativecommunity.webview.RNCWebView
 import com.reactnativecommunity.webview.extension.file.Base64FileDownloader.downloadBase64File
@@ -8,13 +7,13 @@ import java.io.IOException
 
 internal fun RNCWebView.addBlobFileDownloaderJavascriptInterface(downloadingMessage: String, requestFilePermission: (String) -> Unit) {
 	this.addJavascriptInterface(
-		BlobFileDownloader(this.context, downloadingMessage, requestFilePermission),
+		BlobFileDownloader(this, downloadingMessage, requestFilePermission),
 		BlobFileDownloader.JS_INTERFACE_TAG,
 	)
 }
 
 internal class BlobFileDownloader(
-	private val context: Context,
+	private val webView: RNCWebView,
 	private val downloadingMessage: String,
 	private val requestFilePermission: (String) -> Unit,
 ) {
@@ -22,7 +21,10 @@ internal class BlobFileDownloader(
 	@JavascriptInterface
 	@Throws(IOException::class)
 	fun getBase64FromBlobData(base64: String) {
-		downloadBase64File(context, base64, downloadingMessage, requestFilePermission)
+		if (!webView.allowFileDownloads) {
+			return
+		}
+		downloadBase64File(webView.context, base64, downloadingMessage, requestFilePermission)
 	}
 
 	companion object {

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -208,9 +208,21 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
     }
 
     @Override
+    @ReactProp(name = "allowFileDownloads", defaultBoolean = true)
+    public void setAllowFileDownloads(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setAllowFileDownloads(view, value);
+    }
+
+    @Override
     @ReactProp(name = "hasOnOpenWindowEvent")
     public void setHasOnOpenWindowEvent(RNCWebViewWrapper view, boolean hasEvent) {
         mRNCWebViewManagerImpl.setHasOnOpenWindowEvent(view, hasEvent);
+    }
+
+    @Override
+    @ReactProp(name = "suppressJavaScriptDialogs")
+    public void setSuppressJavaScriptDialogs(RNCWebViewWrapper view, boolean suppress) {
+        mRNCWebViewManagerImpl.setSuppressJavaScriptDialogs(view, suppress);
     }
 
     @Override

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -168,9 +168,19 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         mRNCWebViewManagerImpl.setLackPermissionToDownloadMessage(value);
     }
 
+    @ReactProp(name = "allowFileDownloads", defaultBoolean = true)
+    public void setAllowFileDownloads(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setAllowFileDownloads(view, value);
+    }
+
     @ReactProp(name = "hasOnOpenWindowEvent")
     public void setHasOnOpenWindowEvent(RNCWebViewWrapper view, boolean hasEvent) {
         mRNCWebViewManagerImpl.setHasOnOpenWindowEvent(view, hasEvent);
+    }
+
+    @ReactProp(name = "suppressJavaScriptDialogs")
+    public void setSuppressJavaScriptDialogs(RNCWebViewWrapper view, boolean suppress) {
+        mRNCWebViewManagerImpl.setSuppressJavaScriptDialogs(view, suppress);
     }
 
     @ReactProp(name = "mediaPlaybackRequiresUserAction")

--- a/apple/RNCWebView.mm
+++ b/apple/RNCWebView.mm
@@ -277,6 +277,7 @@ auto stringToOnLoadingFinishNavigationTypeEnum(std::string value) {
     REMAP_WEBVIEW_STRING_PROP(injectedJavaScriptObject)
     REMAP_WEBVIEW_PROP(javaScriptEnabled)
     REMAP_WEBVIEW_PROP(javaScriptCanOpenWindowsAutomatically)
+    REMAP_WEBVIEW_PROP(suppressJavaScriptDialogs)
     REMAP_WEBVIEW_PROP(allowFileAccessFromFileURLs)
     REMAP_WEBVIEW_PROP(allowUniversalAccessFromFileURLs)
     REMAP_WEBVIEW_PROP(allowsInlineMediaPlayback)

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -97,6 +97,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL cacheEnabled;
 @property (nonatomic, assign) BOOL javaScriptEnabled;
 @property (nonatomic, assign) BOOL javaScriptCanOpenWindowsAutomatically;
+@property (nonatomic, assign) BOOL suppressJavaScriptDialogs;
 @property (nonatomic, assign) BOOL allowFileAccessFromFileURLs;
 @property (nonatomic, assign) BOOL allowUniversalAccessFromFileURLs;
 @property (nonatomic, assign) BOOL allowsLinkPreview;

--- a/apple/RNCWebViewImpl.m
+++ b/apple/RNCWebViewImpl.m
@@ -1268,6 +1268,10 @@ RCTAutoInsetsProtocol>
  */
 - (void)webView:(WKWebView *)webView runJavaScriptAlertPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(void))completionHandler
 {
+  if (_suppressJavaScriptDialogs) {
+    completionHandler();
+    return;
+  }
 #if !TARGET_OS_OSX
   UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"" message:message preferredStyle:UIAlertControllerStyleAlert];
   [alert addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
@@ -1287,6 +1291,10 @@ RCTAutoInsetsProtocol>
  * confirm
  */
 - (void)webView:(WKWebView *)webView runJavaScriptConfirmPanelWithMessage:(NSString *)message initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(BOOL))completionHandler{
+  if (_suppressJavaScriptDialogs) {
+    completionHandler(NO);
+    return;
+  }
 #if !TARGET_OS_OSX
   UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"" message:message preferredStyle:UIAlertControllerStyleAlert];
   [alert addAction:[UIAlertAction actionWithTitle:@"Ok" style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction *action) {
@@ -1312,6 +1320,10 @@ RCTAutoInsetsProtocol>
  * prompt
  */
 - (void)webView:(WKWebView *)webView runJavaScriptTextInputPanelWithPrompt:(NSString *)prompt defaultText:(NSString *)defaultText initiatedByFrame:(WKFrameInfo *)frame completionHandler:(void (^)(NSString *))completionHandler{
+  if (_suppressJavaScriptDialogs) {
+    completionHandler(nil);
+    return;
+  }
   if (!_disablePromptDuringLoading) {
 #if !TARGET_OS_OSX
   UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"" message:prompt preferredStyle:UIAlertControllerStyleAlert];

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -59,6 +59,7 @@ RCT_EXPORT_VIEW_PROPERTY(injectedJavaScriptBeforeContentLoadedForMainFrameOnly, 
 RCT_EXPORT_VIEW_PROPERTY(injectedJavaScriptObject, NSString)
 RCT_EXPORT_VIEW_PROPERTY(javaScriptEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(javaScriptCanOpenWindowsAutomatically, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(suppressJavaScriptDialogs, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowFileAccessFromFileURLs, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowUniversalAccessFromFileURLs, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsInlineMediaPlayback, BOOL)

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -38,6 +38,7 @@ This document lays out the current public properties and methods for the React N
 - [`domStorageEnabled`](Reference.md#domstorageenabled)
 - [`javaScriptEnabled`](Reference.md#javascriptenabled)
 - [`javaScriptCanOpenWindowsAutomatically`](Reference.md#javascriptcanopenwindowsautomatically)
+- [`suppressJavaScriptDialogs`](Reference.md#suppressjavascriptdialogs)
 - [`androidLayerType`](Reference.md#androidLayerType)
 - [`mixedContentMode`](Reference.md#mixedcontentmode)
 - [`thirdPartyCookiesEnabled`](Reference.md#thirdpartycookiesenabled)
@@ -91,6 +92,7 @@ This document lays out the current public properties and methods for the React N
 - [`minimumFontSize`](Reference.md#minimumFontSize)
 - [`downloadingMessage`](Reference.md#downloadingMessage)
 - [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
+- [`allowFileDownloads`](Reference.md#allowfiledownloads)
 - [`allowsProtectedMedia`](Reference.md#allowsProtectedMedia)
 - [`webviewDebuggingEnabled`](Reference.md#webviewDebuggingEnabled)
 - [`paymentRequestEnabled`](Reference.md#paymentRequestEnabled)
@@ -926,6 +928,16 @@ A Boolean value indicating whether JavaScript can open windows without user inte
 
 ---
 
+### `suppressJavaScriptDialogs`[⬆](#props-index)
+
+Boolean value to suppress JavaScript dialogs (alert/confirm/prompt). The default value is `false`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android, iOS |
+
+---
+
 ### `androidLayerType`[⬆](#props-index)
 
 Specifies the layer type.
@@ -1692,6 +1704,14 @@ This is the message that is shown in the Toast when the webview is unable to dow
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
 | string | No       | Android  |
+
+### `allowFileDownloads`[⬆](#props-index)
+
+Boolean value to control whether file downloads are allowed. The default value is `true`.
+
+| Type | Required | Platform |
+| ---- | -------- | -------- |
+| bool | No       | Android  |
 
 ### `allowsProtectedMedia`[⬆](#props-index)
 

--- a/example/examples/Alerts.tsx
+++ b/example/examples/Alerts.tsx
@@ -1,5 +1,5 @@
-import React, {Component} from 'react';
-import {Text, View} from 'react-native';
+import React, { useState } from 'react';
+import { StyleSheet, Switch, Text, View } from 'react-native';
 
 import WebView from '@metamask/react-native-webview';
 
@@ -13,9 +13,15 @@ const HTML = `
     <style type="text/css">
       body {
         margin: 0;
-        padding: 0;
+        padding: 8px;
         font: 62.5% arial, sans-serif;
         background: #ccc;
+      }
+      #demo {
+        margin-top: 8px;
+        padding: 8px;
+        background: #fff;
+        border-radius: 4px;
       }
     </style>
   </head>
@@ -23,7 +29,7 @@ const HTML = `
     <button onclick="showAlert()">Show alert</button>
     <button onclick="showConfirm()">Show confirm</button>
     <button onclick="showPrompt()">Show prompt</button>
-    <p id="demo"></p>    
+    <p id="demo">Result will appear here...</p>    
     <script>
       function showAlert() {
         alert("Hello! I am an alert box!");
@@ -53,20 +59,62 @@ const HTML = `
 </html>
 `;
 
-type Props = {};
-type State = {};
+export default function Alerts() {
+  const [suppressJavaScriptDialogs, setSuppressJavaScriptDialogs] =
+    useState(false);
+  const [key, setKey] = useState(0);
 
-export default class Alerts extends Component<Props, State> {
-  state = {};
+  const handleToggle = (value: boolean) => {
+    setSuppressJavaScriptDialogs(value);
+    setKey((k) => k + 1);
+  };
 
-  render() {
-    return (
-      <View style={{ height: 120 }}>
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Text style={styles.label}>suppressJavaScriptDialogs</Text>
+        <Switch
+          value={suppressJavaScriptDialogs}
+          onValueChange={handleToggle}
+        />
+        <Text style={styles.value}>
+          {suppressJavaScriptDialogs ? 'ON' : 'OFF'}
+        </Text>
+      </View>
+      <View style={styles.webviewContainer}>
         <WebView
-          source={{html: HTML}}
+          key={key}
+          source={{ html: HTML }}
           automaticallyAdjustContentInsets={false}
+          suppressJavaScriptDialogs={suppressJavaScriptDialogs}
         />
       </View>
-    );
-  }
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    marginBottom: 8,
+  },
+  label: {
+    flex: 1,
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  value: {
+    width: 32,
+    fontSize: 11,
+    color: '#666',
+    textAlign: 'right',
+  },
+  webviewContainer: {
+    flex: 1,
+  },
+});

--- a/example/examples/Downloads.tsx
+++ b/example/examples/Downloads.tsx
@@ -1,7 +1,7 @@
-import React, {Component} from 'react';
-import {Alert, Platform, View} from 'react-native';
+import React, { useState } from 'react';
+import { Alert, Platform, StyleSheet, Switch, Text, View } from 'react-native';
 
-import WebView, {FileDownload} from '@metamask/react-native-webview';
+import WebView, { FileDownload } from '@metamask/react-native-webview';
 
 const HTML = `
 <!DOCTYPE html>\n
@@ -13,45 +13,78 @@ const HTML = `
     <style type="text/css">
       body {
         margin: 0;
-        padding: 0;
+        padding: 8px;
         font: 62.5% arial, sans-serif;
         background: #ccc;
+      }
+      a {
+        display: block;
+        margin: 8px 0;
       }
     </style>
   </head>
   <body>
     <a href="https://www.7-zip.org/a/7za920.zip">Example zip file download</a>
-    <br>
     <a href="http://test.greenbytes.de/tech/tc2231/attwithisofn2231iso.asis">Download file with non-ascii filename: "foo-ä.html"</a>
   </body>
 </html>
 `;
 
-interface Props {}
-interface State {}
+export default function Downloads() {
+  const [allowFileDownloads, setAllowFileDownloads] = useState(true);
+  const [key, setKey] = useState(0);
 
-export default class Downloads extends Component<Props, State> {
-  state = {};
-
-  onFileDownload = ({ nativeEvent }: { nativeEvent: FileDownload } ) => {
-    Alert.alert("File download detected", nativeEvent.downloadUrl);
+  const onFileDownload = ({ nativeEvent }: { nativeEvent: FileDownload }) => {
+    Alert.alert('File download detected', nativeEvent.downloadUrl);
   };
 
-  render() {
-    const platformProps = Platform.select({
-      ios: {
-        onFileDownload: this.onFileDownload,
-      },
-    });
+  const handleToggle = (value: boolean) => {
+    setAllowFileDownloads(value);
+    setKey((k) => k + 1);
+  };
 
-    return (
-      <View style={{ height: 120 }}>
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Text style={styles.label}>allowFileDownloads</Text>
+        <Switch value={allowFileDownloads} onValueChange={handleToggle} />
+        <Text style={styles.value}>{allowFileDownloads ? 'ON' : 'OFF'}</Text>
+      </View>
+      <View style={styles.webviewContainer}>
         <WebView
-          source={{html: HTML}}
+          key={key}
+          source={{ html: HTML }}
           automaticallyAdjustContentInsets={false}
-          {...platformProps}
+          allowFileDownloads={allowFileDownloads}
+          onFileDownload={Platform.OS === 'ios' ? onFileDownload : undefined}
         />
       </View>
-    );
-  }
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    marginBottom: 8,
+  },
+  label: {
+    flex: 1,
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  value: {
+    width: 32,
+    fontSize: 11,
+    color: '#666',
+    textAlign: 'right',
+  },
+  webviewContainer: {
+    flex: 1,
+  },
+});

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@react-native/typescript-config/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@metamask/react-native-webview": ["../src/index"],
+      "react-native-webview": ["../src/index"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/metro.config.js
+++ b/metro.config.js
@@ -8,6 +8,7 @@ module.exports = makeMetroConfig({
     resolverMainFields: ['main-internal', 'browser', 'main'],
     extraNodeModules: {
       'react-native-webview': __dirname,
+      '@metamask/react-native-webview': __dirname,
     },
   },
   transformer: {

--- a/src/RNCWebViewNativeComponent.ts
+++ b/src/RNCWebViewNativeComponent.ts
@@ -160,6 +160,7 @@ export interface NativeProps extends ViewProps {
   forceDarkOn?: boolean;
   geolocationEnabled?: boolean;
   lackPermissionToDownloadMessage?: string;
+  allowFileDownloads?: boolean;
   messagingModuleName: string;
   minimumFontSize?: Int32;
   mixedContentMode?: WithDefault<'never' | 'always' | 'compatibility', 'never'>;
@@ -265,6 +266,7 @@ export interface NativeProps extends ViewProps {
     true
   >;
   javaScriptCanOpenWindowsAutomatically?: boolean;
+  suppressJavaScriptDialogs?: boolean;
   javaScriptEnabled?: WithDefault<boolean, true>;
   webviewDebuggingEnabled?: boolean;
   mediaPlaybackRequiresUserAction?: WithDefault<boolean, true>;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1141,6 +1141,13 @@ export interface AndroidWebViewProps extends WebViewSharedProps {
   lackPermissionToDownloadMessage?: string;
 
   /**
+   * Boolean value to control whether file downloads are allowed.
+   * The default value is `true`.
+   * @platform android
+   */
+  allowFileDownloads?: boolean;
+
+  /**
    * Boolean value to control whether webview can play media protected by DRM.
    * Default is false.
    * @platform android
@@ -1166,6 +1173,13 @@ export interface WebViewSharedProps extends ViewProps {
    * The default value is `false`.
    */
   javaScriptCanOpenWindowsAutomatically?: boolean;
+
+  /**
+   * Boolean value to suppress JavaScript dialogs (alert/confirm/prompt).
+   * The default value is `false`.
+   * @platform android, ios
+   */
+  suppressJavaScriptDialogs?: boolean;
 
   /**
    * Stylesheet object to set the style of the container view.


### PR DESCRIPTION
Add two new props:

`allowFileDownloads` - block all downloads that could be triggered by WebView (could be toggled during runtime)
`suppressJavaScriptDialogs` - block all JS dialogs (alert/prompt/confirm) (could be toggled during runtime)

I also added code to test these props to example app and fixed some TS errors by creating proper `tsconfig.json`  for example app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new runtime-configurable props and wires them through native code and types.
> 
> - **New props**: `suppressJavaScriptDialogs` (Android, iOS) to block `alert/confirm/prompt`; `allowFileDownloads` (Android) to disable all downloads
> - **Android**: gate downloads in `RNCWebView`, `RNCWebViewManagerImpl` `DownloadListener`, and `BlobFileDownloader`; add JS dialog suppression via `RNCWebChromeClient` (`onJsAlert/Confirm/Prompt`) with `shouldSuppressDialogs()`; expose props via old/new arch managers
> - **iOS**: suppress JS dialogs in `RNCWebViewImpl` by short-circuiting alert/confirm/prompt handlers; export prop in `RNCWebViewManager.mm` and map in `RNCWebView.mm`
> - **Types/bridge**: add props to `RNCWebViewNativeComponent.ts` and `WebViewTypes.ts`
> - **Docs/examples**: document both props in `docs/Reference.md`; add toggles and demos in `example/examples/Alerts.tsx` and `Downloads.tsx`; add example `tsconfig.json` and update `metro.config.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e9ec5edf0bda2df7f0132036a186b6a9de004f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->