### PR TITLE
Enables iab to redirect calls to MockServer on E2E context

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebView.java
@@ -111,6 +111,24 @@ public class RNCWebView extends WebView implements LifecycleEventListener {
         mRNCWebViewClient.setBasicAuthCredential(credential);
     }
 
+    /**
+     * E2E Testing: Enable E2E mode for request interception
+     */
+    public void setE2EMode(boolean enabled) {
+        if (mRNCWebViewClient != null) {
+            mRNCWebViewClient.setE2EMode(enabled);
+        }
+    }
+
+    /**
+     * E2E Testing: Set mock server URL for request proxying
+     */
+    public void setMockServerUrl(@Nullable String url) {
+        if (mRNCWebViewClient != null) {
+            mRNCWebViewClient.setMockServerUrl(url);
+        }
+    }
+
     public void setSendContentSizeChangeEvents(boolean sendContentSizeChangeEvents) {
         this.sendContentSizeChangeEvents = sendContentSizeChangeEvents;
     }

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManagerImpl.kt
@@ -611,6 +611,22 @@ class RNCWebViewManagerImpl(private val newArch: Boolean = false) {
         view.settings.allowFileAccessFromFileURLs = value;
     }
 
+    /**
+     * E2E Testing: Enable E2E mode for request interception
+     */
+    fun setE2EMode(viewWrapper: RNCWebViewWrapper, enabled: Boolean) {
+        val view = viewWrapper.webView
+        view.setE2EMode(enabled)
+    }
+
+    /**
+     * E2E Testing: Set mock server URL for request proxying
+     */
+    fun setMockServerUrl(viewWrapper: RNCWebViewWrapper, url: String?) {
+        val view = viewWrapper.webView
+        view.setMockServerUrl(url)
+    }
+
     fun setAllowsFullscreenVideo(viewWrapper: RNCWebViewWrapper, value: Boolean) {
         val view = viewWrapper.webView
         mAllowsFullscreenVideo = value

--- a/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/newarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -349,6 +349,16 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper>
         mRNCWebViewManagerImpl.setPaymentRequestEnabled(view, value);
     }
 
+    @ReactProp(name = "e2eMode")
+    public void setE2EMode(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setE2EMode(view, value);
+    }
+
+    @ReactProp(name = "mockServerUrl")
+    public void setMockServerUrl(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setMockServerUrl(view, value);
+    }
+
     /* iOS PROPS - no implemented here */
     @Override
     public void setAllowingReadAccessToURL(RNCWebViewWrapper view, @Nullable String value) {}

--- a/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/oldarch/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -288,6 +288,16 @@ public class RNCWebViewManager extends ViewGroupManager<RNCWebViewWrapper> {
         mRNCWebViewManagerImpl.setPaymentRequestEnabled(view, value);
     }
 
+    @ReactProp(name = "e2eMode")
+    public void setE2EMode(RNCWebViewWrapper view, boolean value) {
+        mRNCWebViewManagerImpl.setE2EMode(view, value);
+    }
+
+    @ReactProp(name = "mockServerUrl")
+    public void setMockServerUrl(RNCWebViewWrapper view, @Nullable String value) {
+        mRNCWebViewManagerImpl.setMockServerUrl(view, value);
+    }
+
     @Override
     protected void addEventEmitters(@NonNull ThemedReactContext reactContext, RNCWebViewWrapper viewWrapper) {
         // Do not register default touch emitter and let WebView implementation handle touches

--- a/apple/RNCWebViewImpl.h
+++ b/apple/RNCWebViewImpl.h
@@ -107,6 +107,9 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
 @property (nonatomic, assign) BOOL ignoreSilentHardwareSwitch;
 @property (nonatomic, copy) NSString * _Nullable allowingReadAccessToURL;
 @property (nonatomic, copy) NSDictionary * _Nullable basicAuthCredential;
+// E2E Testing: Properties for request interception (currently handled via JS injection)
+@property (nonatomic, assign) BOOL e2eMode;
+@property (nonatomic, copy) NSString * _Nullable mockServerUrl;
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
 @property (nonatomic, assign) BOOL refreshControlLightMode;
 @property (nonatomic, assign) BOOL enableApplePay;

--- a/apple/RNCWebViewManager.mm
+++ b/apple/RNCWebViewManager.mm
@@ -80,6 +80,9 @@ RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowingReadAccessToURL, NSString)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
+// E2E Testing: Properties for request interception (currently handled via JS injection)
+RCT_EXPORT_VIEW_PROPERTY(e2eMode, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(mockServerUrl, NSString)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)


### PR DESCRIPTION
# Summary
Add native E2E request interception support for Android WebView to enable routing all network requests through the mock server during E2E tests.

# Motivation
During E2E testing, API calls made from the in-app browser (WebView) were not being intercepted by the mock server. This is because the existing mock server implementation patches fetch and XMLHttpRequest in the React Native JavaScript context (shim.js), but WebView runs in a separate browser context with its own network stack.
This PR adds native-level request interception on Android using shouldInterceptRequest, which intercepts ALL network requests from the WebView (including page navigation, resources, and API calls) and routes them through the mock server proxy.

## Changes
**Android Native Code**
`RNCWebViewClient.java`:
- Added mE2EMode and mMockServerUrl member variables
- Added setE2EMode() and setMockServerUrl() public methods
- Implemented shouldInterceptRequest() to intercept HTTP/HTTPS requests and route them through the mock server proxy (/proxy?url=...)
- Added isLocalOrMockServerUrl() helper to bypass interception for localhost/mock server URLs (prevents infinite loops)

`RNCWebView.java`:
-Added setE2EMode() and setMockServerUrl() methods that forward to RNCWebViewClient

`RNCWebViewManagerImpl.kt`:
- Added setE2EMode() and setMockServerUrl() functions

`RNCWebViewManager.java (oldarch & newarch)`:
- Added @ReactProp annotations for e2eMode (boolean) and mockServerUrl (String)

**iOS Native Code**
`RNCWebViewImpl.h`:
- Added e2eMode and mockServerUrl properties (for future native implementation)

`RNCWebViewManager.mm`:
- Added RCT_EXPORT_VIEW_PROPERTY for e2eMode and mockServerUrl

> Note: iOS currently relies on JavaScript injection for fetch/XHR interception. Native iOS interception via NSURLProtocol can be added in a future PR if needed.

## Usage
<WebView  e2eMode={true}  mockServerUrl="http://localhost:8000"  // ... other props/>
When e2eMode is true and mockServerUrl is provided, the Android WebView will:
1. Intercept all HTTP/HTTPS requests via shouldInterceptRequest
2. Route them through {mockServerUrl}/proxy?url={encodedOriginalUrl}
3 Return the proxied response to the WebView

## Testing
- Verified E2E tests can now intercept and mock WebView network requests
- Verified non-E2E builds are unaffected (props default to false/null)
- Verified localhost/mock server URLs are bypassed to prevent infinite loops

## Related
Consumer PR: [MetaMask/metamask-mobile#25652](https://github.com/MetaMask/metamask-mobile/pull/25652)